### PR TITLE
Add basic UI screens and routing

### DIFF
--- a/lib/core/events_page.dart
+++ b/lib/core/events_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/event.dart';
+import '../providers/event_provider.dart';
+
+/// Displays a list of camp events.
+class EventsPage extends StatelessWidget {
+  const EventsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final events = context.watch<EventProvider>().events;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Events')),
+      body: ListView.builder(
+        itemCount: events.length,
+        itemBuilder: (context, index) {
+          final event = events[index];
+          return ListTile(
+            title: Text(event.title),
+            subtitle: Text(event.description),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          final id = DateTime.now().millisecondsSinceEpoch.toString();
+          context.read<EventProvider>().addEvent(
+                Event(
+                  id: id,
+                  title: 'Event $id',
+                  description: 'Description for event $id',
+                  date: DateTime.now(),
+                ),
+              );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+

--- a/lib/core/home_page.dart
+++ b/lib/core/home_page.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+import '../routes/app_routes.dart';
 
 /// Basic home screen shown after launch.
 class HomePage extends StatelessWidget {
@@ -8,8 +12,34 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Camp Leader')),
-      body: const Center(
-        child: Text('Welcome to camp management!'),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Welcome to camp management!'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () =>
+                  Navigator.pushNamed(context, AppRoutes.events),
+              child: const Text('View Events'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () =>
+                  Navigator.pushNamed(context, AppRoutes.tasks),
+              child: const Text('View Tasks'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () {
+                context.read<AuthProvider>().logout();
+                Navigator.pushReplacementNamed(
+                    context, AppRoutes.login);
+              },
+              child: const Text('Logout'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/core/login_page.dart
+++ b/lib/core/login_page.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+import '../routes/app_routes.dart';
+
+/// Simple login screen where the leader enters their name.
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final TextEditingController _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final name = _nameController.text.trim();
+                if (name.isNotEmpty) {
+                  await context.read<AuthProvider>().login(name);
+                  if (!mounted) return;
+                  Navigator.pushReplacementNamed(context, AppRoutes.home);
+                }
+              },
+              child: const Text('Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/core/tasks_page.dart
+++ b/lib/core/tasks_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/task.dart';
+import '../providers/task_provider.dart';
+
+/// Displays a list of tasks that can be toggled complete/incomplete.
+class TasksPage extends StatelessWidget {
+  const TasksPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final taskProvider = context.watch<TaskProvider>();
+    final tasks = taskProvider.tasks;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tasks')),
+      body: ListView.builder(
+        itemCount: tasks.length,
+        itemBuilder: (context, index) {
+          final task = tasks[index];
+          return CheckboxListTile(
+            title: Text(task.description),
+            value: task.isCompleted,
+            onChanged: (_) => taskProvider.toggleTask(task.id),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          final id = DateTime.now().millisecondsSinceEpoch.toString();
+          context.read<TaskProvider>().addTask(
+                Task(id: id, description: 'Task $id'),
+              );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ class CampLeaderApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Camp Leader',
         routes: AppRoutes.routes,
-        initialRoute: AppRoutes.home,
+        initialRoute: AppRoutes.login,
       ),
     );
   }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,13 +1,22 @@
 import 'package:flutter/material.dart';
 
+import '../core/events_page.dart';
 import '../core/home_page.dart';
+import '../core/login_page.dart';
+import '../core/tasks_page.dart';
 
 /// Central definition of named routes used in the application.
 class AppRoutes {
-  static const home = '/';
+  static const login = '/';
+  static const home = '/home';
+  static const events = '/events';
+  static const tasks = '/tasks';
 
   static final Map<String, WidgetBuilder> routes = {
+    login: (context) => const LoginPage(),
     home: (context) => const HomePage(),
+    events: (context) => const EventsPage(),
+    tasks: (context) => const TasksPage(),
   };
 }
 


### PR DESCRIPTION
## Summary
- add login, events, and tasks screens
- wire routes for navigation and home links
- set login screen as initial route

## Testing
- `dart format lib` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68908d1a15ac832395b6b01a69b074ba