### PR TITLE
Add navigation bar, theme, validation, and local persistence

### DIFF
--- a/lib/core/constants/colors.dart
+++ b/lib/core/constants/colors.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+/// Application color palette.
+class AppColors {
+  /// Primary brand color used for theming.
+  static const Color primary = Colors.green;
+}

--- a/lib/core/events_page.dart
+++ b/lib/core/events_page.dart
@@ -3,41 +3,90 @@ import 'package:provider/provider.dart';
 
 import '../models/event.dart';
 import '../providers/event_provider.dart';
+import 'widgets/bottom_nav.dart';
 
 /// Displays a list of camp events.
 class EventsPage extends StatelessWidget {
   const EventsPage({super.key});
 
+  Future<void> _addEvent(BuildContext context) async {
+    final titleController = TextEditingController();
+    final descController = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New Event'),
+        content: Form(
+          key: formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextFormField(
+                controller: titleController,
+                decoration: const InputDecoration(labelText: 'Title'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: descController,
+                decoration: const InputDecoration(labelText: 'Description'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                final id = DateTime.now().millisecondsSinceEpoch.toString();
+                context.read<EventProvider>().addEvent(
+                      Event(
+                        id: id,
+                        title: titleController.text.trim(),
+                        description: descController.text.trim(),
+                        date: DateTime.now(),
+                      ),
+                    );
+                Navigator.pop(context);
+              }
+            },
+            child: const Text('Add'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final events = context.watch<EventProvider>().events;
     return Scaffold(
       appBar: AppBar(title: const Text('Events')),
-      body: ListView.builder(
-        itemCount: events.length,
-        itemBuilder: (context, index) {
-          final event = events[index];
-          return ListTile(
-            title: Text(event.title),
-            subtitle: Text(event.description),
+      bottomNavigationBar: const CustomBottomNav(currentIndex: 1),
+      body: Consumer<EventProvider>(
+        builder: (context, provider, _) {
+          final events = provider.events;
+          return ListView.builder(
+            itemCount: events.length,
+            itemBuilder: (context, index) {
+              final event = events[index];
+              return ListTile(
+                title: Text(event.title),
+                subtitle: Text(event.description),
+              );
+            },
           );
         },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          final id = DateTime.now().millisecondsSinceEpoch.toString();
-          context.read<EventProvider>().addEvent(
-                Event(
-                  id: id,
-                  title: 'Event $id',
-                  description: 'Description for event $id',
-                  date: DateTime.now(),
-                ),
-              );
-        },
+        onPressed: () => _addEvent(context),
         child: const Icon(Icons.add),
       ),
     );
   }
 }
-

--- a/lib/core/home_page.dart
+++ b/lib/core/home_page.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 
 import '../providers/auth_provider.dart';
 import '../routes/app_routes.dart';
+import 'widgets/bottom_nav.dart';
+import 'widgets/custom_button.dart';
 
 /// Basic home screen shown after launch.
 class HomePage extends StatelessWidget {
@@ -12,31 +14,19 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Camp Leader')),
+      bottomNavigationBar: const CustomBottomNav(currentIndex: 0),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Text('Welcome to camp management!'),
             const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () =>
-                  Navigator.pushNamed(context, AppRoutes.events),
-              child: const Text('View Events'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () =>
-                  Navigator.pushNamed(context, AppRoutes.tasks),
-              child: const Text('View Tasks'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
+            CustomButton(
+              label: 'Logout',
               onPressed: () {
                 context.read<AuthProvider>().logout();
-                Navigator.pushReplacementNamed(
-                    context, AppRoutes.login);
+                Navigator.pushReplacementNamed(context, AppRoutes.login);
               },
-              child: const Text('Logout'),
             ),
           ],
         ),
@@ -44,4 +34,3 @@ class HomePage extends StatelessWidget {
     );
   }
 }
-

--- a/lib/core/login_page.dart
+++ b/lib/core/login_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/auth_provider.dart';
 import '../routes/app_routes.dart';
+import 'widgets/custom_button.dart';
 
 /// Simple login screen where the leader enters their name.
 class LoginPage extends StatefulWidget {
@@ -14,6 +15,7 @@ class LoginPage extends StatefulWidget {
 
 class _LoginPageState extends State<LoginPage> {
   final TextEditingController _nameController = TextEditingController();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   @override
   void dispose() {
@@ -27,29 +29,33 @@ class _LoginPageState extends State<LoginPage> {
       appBar: AppBar(title: const Text('Login')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Name'),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () async {
-                final name = _nameController.text.trim();
-                if (name.isNotEmpty) {
-                  await context.read<AuthProvider>().login(name);
-                  if (!mounted) return;
-                  Navigator.pushReplacementNamed(context, AppRoutes.home);
-                }
-              },
-              child: const Text('Login'),
-            ),
-          ],
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (value) =>
+                    value == null || value.trim().isEmpty ? 'Enter your name' : null,
+              ),
+              const SizedBox(height: 16),
+              CustomButton(
+                label: 'Login',
+                onPressed: () async {
+                  if (_formKey.currentState!.validate()) {
+                    final name = _nameController.text.trim();
+                    await context.read<AuthProvider>().login(name);
+                    if (!mounted) return;
+                    Navigator.pushReplacementNamed(context, AppRoutes.home);
+                  }
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
-

--- a/lib/core/widgets/bottom_nav.dart
+++ b/lib/core/widgets/bottom_nav.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../routes/app_routes.dart';
+
+/// Bottom navigation bar used across pages for quick navigation.
+class CustomBottomNav extends StatelessWidget {
+  final int currentIndex;
+  const CustomBottomNav({super.key, required this.currentIndex});
+
+  void _onTap(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        Navigator.pushReplacementNamed(context, AppRoutes.home);
+        break;
+      case 1:
+        Navigator.pushReplacementNamed(context, AppRoutes.events);
+        break;
+      case 2:
+        Navigator.pushReplacementNamed(context, AppRoutes.tasks);
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: (i) => _onTap(context, i),
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+        BottomNavigationBarItem(icon: Icon(Icons.event), label: 'Events'),
+        BottomNavigationBarItem(icon: Icon(Icons.check), label: 'Tasks'),
+      ],
+    );
+  }
+}

--- a/lib/core/widgets/custom_button.dart
+++ b/lib/core/widgets/custom_button.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Reusable elevated button with unified styling.
+class CustomButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const CustomButton({super.key, required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: Text(label),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'providers/auth_provider.dart';
 import 'providers/event_provider.dart';
 import 'providers/task_provider.dart';
 import 'routes/app_routes.dart';
+import 'theme.dart';
 
 void main() {
   runApp(const CampLeaderApp());
@@ -24,10 +25,10 @@ class CampLeaderApp extends StatelessWidget {
       ],
       child: MaterialApp(
         title: 'Camp Leader',
+        theme: AppTheme.lightTheme,
         routes: AppRoutes.routes,
         initialRoute: AppRoutes.login,
       ),
     );
   }
 }
-

--- a/lib/providers/event_provider.dart
+++ b/lib/providers/event_provider.dart
@@ -7,11 +7,19 @@ import '../services/database_service.dart';
 class EventProvider extends ChangeNotifier {
   final DatabaseService _db = DatabaseService();
 
+  EventProvider() {
+    _init();
+  }
+
   List<Event> get events => _db.events;
 
-  void addEvent(Event event) {
-    _db.addEvent(event);
+  Future<void> _init() async {
+    await _db.loadEvents();
+    notifyListeners();
+  }
+
+  Future<void> addEvent(Event event) async {
+    await _db.addEvent(event);
     notifyListeners();
   }
 }
-

--- a/lib/providers/task_provider.dart
+++ b/lib/providers/task_provider.dart
@@ -7,17 +7,26 @@ import '../services/database_service.dart';
 class TaskProvider extends ChangeNotifier {
   final DatabaseService _db = DatabaseService();
 
+  TaskProvider() {
+    _init();
+  }
+
   List<Task> get tasks => _db.tasks;
 
-  void addTask(Task task) {
-    _db.addTask(task);
+  Future<void> _init() async {
+    await _db.loadTasks();
     notifyListeners();
   }
 
-  void toggleTask(String id) {
+  Future<void> addTask(Task task) async {
+    await _db.addTask(task);
+    notifyListeners();
+  }
+
+  Future<void> toggleTask(String id) async {
     final task = _db.tasks.firstWhere((t) => t.id == id);
     task.isCompleted = !task.isCompleted;
+    await _db.updateTask(task);
     notifyListeners();
   }
 }
-

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,16 +1,48 @@
 import '../models/event.dart';
 import '../models/task.dart';
+import 'local_storage_service.dart';
 
-/// In-memory database used for the prototype application.
+/// Repository that persists data using [LocalStorageService].
 class DatabaseService {
+  final LocalStorageService _storage = LocalStorageService();
   final List<Event> _events = [];
   final List<Task> _tasks = [];
 
   List<Event> get events => List.unmodifiable(_events);
   List<Task> get tasks => List.unmodifiable(_tasks);
 
-  void addEvent(Event event) => _events.add(event);
+  /// Loads events from local storage.
+  Future<void> loadEvents() async {
+    _events
+      ..clear()
+      ..addAll(await _storage.loadEvents());
+  }
 
-  void addTask(Task task) => _tasks.add(task);
+  /// Loads tasks from local storage.
+  Future<void> loadTasks() async {
+    _tasks
+      ..clear()
+      ..addAll(await _storage.loadTasks());
+  }
+
+  /// Adds a new event and persists the list.
+  Future<void> addEvent(Event event) async {
+    _events.add(event);
+    await _storage.saveEvents(_events);
+  }
+
+  /// Adds a new task and persists the list.
+  Future<void> addTask(Task task) async {
+    _tasks.add(task);
+    await _storage.saveTasks(_tasks);
+  }
+
+  /// Updates an existing task and persists the list.
+  Future<void> updateTask(Task task) async {
+    final index = _tasks.indexWhere((t) => t.id == task.id);
+    if (index != -1) {
+      _tasks[index] = task;
+      await _storage.saveTasks(_tasks);
+    }
+  }
 }
-

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/event.dart';
+import '../models/task.dart';
+
+/// Handles persistence using [SharedPreferences].
+class LocalStorageService {
+  static const _eventsKey = 'events';
+  static const _tasksKey = 'tasks';
+
+  Future<List<Event>> loadEvents() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getStringList(_eventsKey) ?? [];
+    return data
+        .map((e) => Event.fromJson(jsonDecode(e) as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveEvents(List<Event> events) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = events.map((e) => jsonEncode(e.toJson())).toList();
+    await prefs.setStringList(_eventsKey, data);
+  }
+
+  Future<List<Task>> loadTasks() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getStringList(_tasksKey) ?? [];
+    return data
+        .map((e) => Task.fromJson(jsonDecode(e) as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveTasks(List<Task> tasks) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = tasks.map((e) => jsonEncode(e.toJson())).toList();
+    await prefs.setStringList(_tasksKey, data);
+  }
+}

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'core/constants/colors.dart';
+
+/// Centralized application theme.
+class AppTheme {
+  /// Light theme used throughout the app.
+  static ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
+        useMaterial3: true,
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,15 @@
+name: camp_leader
+description: Camp leader management app prototype
+version: 1.0.0
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+  shared_preferences: ^2.2.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add centralized AppTheme and color palette
- implement bottom navigation for home, events, and tasks
- persist events and tasks using shared_preferences and provider-based repositories
- add form validation and reusable button widget

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68908e9692d88323b5143c07adf80153