### PR TITLE
feat: add splash screen and dark theme

### DIFF
--- a/lib/core/splash_page.dart
+++ b/lib/core/splash_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/auth_provider.dart';
+import '../routes/app_routes.dart';
+
+/// Splash screen shown while the app initializes.
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    // Simulate asynchronous initialization such as loading data
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
+    final auth = context.read<AuthProvider>();
+    final nextRoute = auth.isLoggedIn ? AppRoutes.home : AppRoutes.login;
+    Navigator.pushReplacementNamed(context, nextRoute);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,8 +26,10 @@ class CampLeaderApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Camp Leader',
         theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
+        themeMode: ThemeMode.system,
         routes: AppRoutes.routes,
-        initialRoute: AppRoutes.login,
+        initialRoute: AppRoutes.splash,
       ),
     );
   }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -4,15 +4,18 @@ import '../core/events_page.dart';
 import '../core/home_page.dart';
 import '../core/login_page.dart';
 import '../core/tasks_page.dart';
+import '../core/splash_page.dart';
 
 /// Central definition of named routes used in the application.
 class AppRoutes {
-  static const login = '/';
+  static const splash = '/';
+  static const login = '/login';
   static const home = '/home';
   static const events = '/events';
   static const tasks = '/tasks';
 
   static final Map<String, WidgetBuilder> routes = {
+    splash: (context) => const SplashPage(),
     login: (context) => const LoginPage(),
     home: (context) => const HomePage(),
     events: (context) => const EventsPage(),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -8,4 +8,13 @@ class AppTheme {
         colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
         useMaterial3: true,
       );
+
+  /// Dark theme following the same color scheme.
+  static ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.primary,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      );
 }


### PR DESCRIPTION
## Summary
- show loading splash screen before app navigation
- add configurable dark theme and route for splash screen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
