### PR TITLE
feat: enhance chat with attachments and statuses

### DIFF
--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -4,12 +4,16 @@ class ChatMessage {
   final String authorId;
   final String text;
   final DateTime timestamp;
+  final List<String> attachments;
+  final List<String> readBy;
 
   ChatMessage({
     required this.id,
     required this.authorId,
     required this.text,
     required this.timestamp,
+    this.attachments = const [],
+    this.readBy = const [],
   });
 
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
@@ -17,6 +21,9 @@ class ChatMessage {
         authorId: json['authorId'] as String,
         text: json['text'] as String,
         timestamp: DateTime.parse(json['timestamp'] as String),
+        attachments:
+            (json['attachments'] as List<dynamic>? ?? []).cast<String>(),
+        readBy: (json['readBy'] as List<dynamic>? ?? []).cast<String>(),
       );
 
   Map<String, dynamic> toJson() => {
@@ -24,5 +31,7 @@ class ChatMessage {
         'authorId': authorId,
         'text': text,
         'timestamp': timestamp.toIso8601String(),
+        'attachments': attachments,
+        'readBy': readBy,
       };
 }

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -1,0 +1,54 @@
+import 'user.dart';
+
+/// Represents an invitation sent to a new participant.
+class Invitation {
+  /// Unique identifier of the invitation document.
+  final String id;
+
+  /// Email address the invitation was sent to.
+  final String email;
+
+  /// Token that must be provided to accept the invitation.
+  final String token;
+
+  /// Roles the user will receive upon accepting the invitation.
+  final Set<UserRole> roles;
+
+  /// Creation timestamp of the invitation.
+  final DateTime createdAt;
+
+  const Invitation({
+    required this.id,
+    required this.email,
+    required this.token,
+    this.roles = const {},
+    required this.createdAt,
+  });
+
+  /// Creates an [Invitation] from JSON.
+  factory Invitation.fromJson(Map<String, dynamic> json) {
+    final roleNames = json['roles'] as List<dynamic>? ?? <dynamic>[];
+    final roles = roleNames
+        .map((e) => UserRole.values.firstWhere(
+              (r) => r.name == e,
+              orElse: () => UserRole.assistant,
+            ))
+        .toSet();
+    return Invitation(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      token: json['token'] as String,
+      roles: roles,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  /// Converts this invitation into JSON.
+  Map<String, dynamic> toJson() => {
+        'email': email,
+        'token': token,
+        'roles': roles.map((e) => e.name).toList(),
+        'createdAt': createdAt.toIso8601String(),
+      };
+}
+

--- a/lib/providers/admin_provider.dart
+++ b/lib/providers/admin_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import '../models/invitation.dart';
+import '../models/user.dart';
+import '../services/admin_service.dart';
+
+/// Provider exposing administrative actions to the widget tree.
+class AdminProvider extends ChangeNotifier {
+  final AdminService _service = AdminService();
+
+  /// Stream of pending invitations.
+  Stream<List<Invitation>> get invitations => _service.invitationsStream();
+
+  /// Creates a new invitation for [email].
+  Future<Invitation> invite(String email, {Set<UserRole> roles = const {}}) {
+    return _service.inviteUser(email, roles: roles);
+  }
+
+  /// Assigns [role] to [userId].
+  Future<void> assignRole(String userId, UserRole role) {
+    return _service.assignRole(userId, role);
+  }
+
+  /// Removes [role] from [userId].
+  Future<void> removeRole(String userId, UserRole role) {
+    return _service.removeRole(userId, role);
+  }
+}
+

--- a/lib/providers/chat_provider.dart
+++ b/lib/providers/chat_provider.dart
@@ -1,22 +1,66 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../models/chat_message.dart';
 import '../services/chat_service.dart';
+import '../services/notification_service.dart';
 
 /// Exposes chat messages and sending capabilities to the widget tree.
 class ChatProvider extends ChangeNotifier {
   final ChatService _service = ChatService();
+  final NotificationService _notifications = NotificationService();
+
+  StreamSubscription<List<ChatMessage>>? _subscription;
+  String? _lastMessageId;
 
   Stream<List<ChatMessage>> get messages => _service.messagesStream();
 
-  /// Sends a new message from the given [authorId].
-  Future<void> send(String authorId, String text) async {
+  /// Starts listening for new messages to trigger local notifications.
+  void startListening(String currentUserId) {
+    _subscription?.cancel();
+    _subscription = _service.messagesStream().listen((msgs) {
+      if (msgs.isEmpty) return;
+      final latest = msgs.last;
+      if (latest.id != _lastMessageId && latest.authorId != currentUserId) {
+        _notifications.showNotification('New message', latest.text);
+        _lastMessageId = latest.id;
+      }
+    });
+  }
+
+  /// Sends a new message from the given [authorId] with optional [attachments].
+  Future<void> send(
+    String authorId,
+    String text, {
+    List<String> attachments = const [],
+  }) async {
     final message = ChatMessage(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       authorId: authorId,
       text: text,
       timestamp: DateTime.now(),
+      attachments: attachments,
     );
     await _service.sendMessage(message);
+  }
+
+  /// Marks message with [messageId] as read by [userId].
+  Future<void> markAsRead(String messageId, String userId) async {
+    await _service.markAsRead(messageId, userId);
+  }
+
+  /// Updates typing status for the current user.
+  Future<void> setTyping(String userId, bool isTyping) async {
+    await _service.setTyping(userId, isTyping);
+  }
+
+  /// Stream of user IDs currently typing.
+  Stream<Set<String>> typingUsers() => _service.typingUsersStream();
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
   }
 }

--- a/lib/services/admin_service.dart
+++ b/lib/services/admin_service.dart
@@ -1,0 +1,72 @@
+import 'dart:math';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/invitation.dart';
+import '../models/user.dart';
+
+/// Provides administrative user management features.
+class AdminService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final Random _random = Random();
+
+  /// Generates a simple random token for invitations.
+  String _generateToken() => _random.nextInt(1 << 32).toRadixString(16);
+
+  /// Creates a new invitation for [email] with optional [roles].
+  Future<Invitation> inviteUser(String email, {Set<UserRole> roles = const {}}) async {
+    final token = _generateToken();
+    final doc = _firestore.collection('invitations').doc();
+    final invitation = Invitation(
+      id: doc.id,
+      email: email,
+      token: token,
+      roles: roles,
+      createdAt: DateTime.now(),
+    );
+    await doc.set(invitation.toJson());
+    // In a real application, an email would be sent to [email] containing
+    // a link or the token. Here we simply persist the invitation.
+    return invitation;
+  }
+
+  /// Assigns [role] to the user with [userId].
+  Future<void> assignRole(String userId, UserRole role) async {
+    final ref = _firestore.collection('users').doc(userId);
+    await _firestore.runTransaction((tx) async {
+      final snapshot = await tx.get(ref);
+      final data = snapshot.data() ?? <String, dynamic>{};
+      final roles = List<String>.from(data['roles'] ?? []);
+      if (!roles.contains(role.name)) {
+        roles.add(role.name);
+        tx.set(ref, {...data, 'roles': roles});
+      }
+    });
+  }
+
+  /// Removes [role] from the user with [userId].
+  Future<void> removeRole(String userId, UserRole role) async {
+    final ref = _firestore.collection('users').doc(userId);
+    await _firestore.runTransaction((tx) async {
+      final snapshot = await tx.get(ref);
+      final data = snapshot.data() ?? <String, dynamic>{};
+      final roles = List<String>.from(data['roles'] ?? []);
+      roles.remove(role.name);
+      tx.set(ref, {...data, 'roles': roles});
+    });
+  }
+
+  /// Streams all pending invitations.
+  Stream<List<Invitation>> invitationsStream() {
+    return _firestore
+        .collection('invitations')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => Invitation.fromJson({
+                  ...doc.data(),
+                  'id': doc.id,
+                }))
+            .toList());
+  }
+}
+

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,10 +1,14 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 
 import '../models/chat_message.dart';
 
 /// Provides simple chat capabilities backed by Firestore.
 class ChatService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseStorage _storage = FirebaseStorage.instance;
 
   /// Streams chat messages ordered by their timestamp.
   Stream<List<ChatMessage>> messagesStream() {
@@ -26,5 +30,45 @@ class ChatService {
         .collection('messages')
         .doc(message.id)
         .set(message.toJson());
+  }
+
+  /// Uploads an attachment [file] and returns its download URL.
+  Future<String> uploadAttachment(File file) async {
+    final name = file.uri.pathSegments.last;
+    final ref = _storage
+        .ref()
+        .child('attachments/${DateTime.now().millisecondsSinceEpoch}_$name');
+    await ref.putFile(file);
+    return ref.getDownloadURL();
+  }
+
+  /// Marks the message with [messageId] as read by [userId].
+  Future<void> markAsRead(String messageId, String userId) async {
+    final doc = _firestore.collection('messages').doc(messageId);
+    await _firestore.runTransaction((transaction) async {
+      final snapshot = await transaction.get(doc);
+      final data = snapshot.data();
+      final readBy = List<String>.from(data?['readBy'] ?? []);
+      if (!readBy.contains(userId)) {
+        readBy.add(userId);
+        transaction.update(doc, {'readBy': readBy});
+      }
+    });
+  }
+
+  /// Updates the typing status for the user with [userId].
+  Future<void> setTyping(String userId, bool isTyping) async {
+    await _firestore
+        .collection('typing')
+        .doc(userId)
+        .set({'isTyping': isTyping});
+  }
+
+  /// Streams the set of user IDs currently typing.
+  Stream<Set<String>> typingUsersStream() {
+    return _firestore.collection('typing').snapshots().map((snapshot) => {
+          for (final doc in snapshot.docs)
+            if (doc.data()['isTyping'] == true) doc.id,
+        });
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -14,6 +14,27 @@ class NotificationService {
     await _plugin.initialize(settings);
   }
 
+  /// Shows an immediate notification with the given [title] and [body].
+  Future<void> showNotification(String title, String body) async {
+    const androidDetails = AndroidNotificationDetails(
+      'messages',
+      'Messages',
+      importance: Importance.max,
+      priority: Priority.high,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+    await _plugin.show(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      title,
+      body,
+      details,
+    );
+  }
+
   Future<void> scheduleReminder(
     int id,
     String title,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   sentry_flutter: ^7.11.1
   connectivity_plus: ^4.0.0
   pdf: ^3.10.4
+  firebase_storage: ^11.0.16
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- add local notification helper to instantly alert about new messages
- extend chat message model with attachments and read tracking
- support uploading attachments, read receipts, and typing status in chat service and provider
- include firebase storage dependency
- introduce invitation model and admin services for user role management

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a81475948323af391d1f3c298aa6