### PR TITLE
feat: add admin user management

### DIFF
--- a/lib/core/admin_users_page.dart
+++ b/lib/core/admin_users_page.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/invitation.dart';
+import '../models/user.dart';
+import '../providers/admin_provider.dart';
+
+/// Administrative page that allows managing users and invitations.
+class AdminUsersPage extends StatelessWidget {
+  const AdminUsersPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final admin = context.watch<AdminProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('User Management')),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text(
+                'Users',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+            ),
+            StreamBuilder<List<User>>(
+              stream: admin.users,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final users = snapshot.data!;
+                return ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: users.length,
+                  itemBuilder: (context, index) {
+                    final user = users[index];
+                    return ListTile(
+                      title: Text(user.name),
+                      subtitle: Text(user.roles.map((r) => r.name).join(', ')),
+                      trailing: PopupMenuButton<String>(
+                        onSelected: (value) {
+                          if (value == 'edit') {
+                            _editRoles(context, admin, user);
+                          } else if (value == 'delete') {
+                            admin.deleteUser(user.id);
+                          }
+                        },
+                        itemBuilder: (context) => const [
+                          PopupMenuItem(value: 'edit', child: Text('Edit Roles')),
+                          PopupMenuItem(value: 'delete', child: Text('Delete')),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+            const Divider(),
+            const Padding(
+              padding: EdgeInsets.all(16),
+              child: Text(
+                'Invitations',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+            ),
+            StreamBuilder<List<Invitation>>(
+              stream: admin.invitations,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final invites = snapshot.data!;
+                return ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: invites.length,
+                  itemBuilder: (context, index) {
+                    final invitation = invites[index];
+                    return ListTile(
+                      title: Text(invitation.email),
+                      subtitle:
+                          Text(invitation.roles.map((r) => r.name).join(', ')),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.check),
+                            onPressed: () =>
+                                _acceptInvite(context, admin, invitation),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () =>
+                                admin.declineInvitation(invitation.id),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _editRoles(
+      BuildContext context, AdminProvider admin, User user) async {
+    final selected = Set<UserRole>.from(user.roles);
+    final result = await showDialog<Set<UserRole>>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(builder: (context, setState) {
+          return AlertDialog(
+            title: const Text('Edit Roles'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: UserRole.values.map((role) {
+                return CheckboxListTile(
+                  value: selected.contains(role),
+                  title: Text(role.name),
+                  onChanged: (checked) {
+                    setState(() {
+                      if (checked == true) {
+                        selected.add(role);
+                      } else {
+                        selected.remove(role);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, selected),
+                child: const Text('Save'),
+              ),
+            ],
+          );
+        });
+      },
+    );
+    if (result != null) {
+      await admin.updateUserRoles(user.id, result);
+    }
+  }
+
+  void _acceptInvite(
+      BuildContext context, AdminProvider admin, Invitation invitation) async {
+    final controller = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('New User Name'),
+        content: TextField(
+          controller: controller,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, controller.text),
+            child: const Text('Accept'),
+          ),
+        ],
+      ),
+    );
+    if (name != null && name.isNotEmpty) {
+      await admin.acceptInvitation(invitation.id, name);
+    }
+  }
+}

--- a/lib/core/settings_page.dart
+++ b/lib/core/settings_page.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import '../models/user.dart';
+import '../providers/auth_provider.dart';
 import '../providers/theme_provider.dart';
+import '../routes/app_router.dart';
 
 /// Simple settings screen allowing the user to choose the theme.
 class SettingsPage extends StatelessWidget {
@@ -9,38 +13,50 @@ class SettingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<ThemeProvider>();
-    final mode = provider.themeMode;
+    final theme = context.watch<ThemeProvider>();
+    final auth = context.watch<AuthProvider>();
+    final mode = theme.themeMode;
+    final tiles = <Widget>[
+      RadioListTile<ThemeMode>(
+        title: const Text('System'),
+        value: ThemeMode.system,
+        groupValue: mode,
+        onChanged: (m) {
+          if (m != null) theme.setThemeMode(m);
+        },
+      ),
+      RadioListTile<ThemeMode>(
+        title: const Text('Light'),
+        value: ThemeMode.light,
+        groupValue: mode,
+        onChanged: (m) {
+          if (m != null) theme.setThemeMode(m);
+        },
+      ),
+      RadioListTile<ThemeMode>(
+        title: const Text('Dark'),
+        value: ThemeMode.dark,
+        groupValue: mode,
+        onChanged: (m) {
+          if (m != null) theme.setThemeMode(m);
+        },
+      ),
+    ];
+
+    final isAdmin =
+        auth.currentUser?.roles.contains(UserRole.admin) ?? false;
+    if (isAdmin) {
+      tiles.add(
+        ListTile(
+          title: const Text('Manage Users'),
+          onTap: () => context.push(AppRouter.adminUsers),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: Column(
-        children: [
-          RadioListTile<ThemeMode>(
-            title: const Text('System'),
-            value: ThemeMode.system,
-            groupValue: mode,
-            onChanged: (m) {
-              if (m != null) provider.setThemeMode(m);
-            },
-          ),
-          RadioListTile<ThemeMode>(
-            title: const Text('Light'),
-            value: ThemeMode.light,
-            groupValue: mode,
-            onChanged: (m) {
-              if (m != null) provider.setThemeMode(m);
-            },
-          ),
-          RadioListTile<ThemeMode>(
-            title: const Text('Dark'),
-            value: ThemeMode.dark,
-            groupValue: mode,
-            onChanged: (m) {
-              if (m != null) provider.setThemeMode(m);
-            },
-          ),
-        ],
-      ),
+      body: ListView(children: tiles),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'routes/app_router.dart';
 import 'theme.dart';
 import 'providers/theme_provider.dart';
 import 'services/notification_service.dart';
+import 'providers/admin_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,9 +24,6 @@ Future<void> main() async {
       runApp(const CampLeaderApp());
     },
   );
-=======
-  await NotificationService().init();
-  runApp(const CampLeaderApp());
 }
 
 /// Root widget for the camp leader application.
@@ -40,6 +38,7 @@ class CampLeaderApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => EventProvider()),
         ChangeNotifierProvider(create: (_) => TaskProvider()),
         ChangeNotifierProvider(create: (_) => ThemeProvider()),
+        ChangeNotifierProvider(create: (_) => AdminProvider()),
       ],
       child: Consumer<ThemeProvider>(
         builder: (context, theme, _) {

--- a/lib/providers/admin_provider.dart
+++ b/lib/providers/admin_provider.dart
@@ -11,6 +11,9 @@ class AdminProvider extends ChangeNotifier {
   /// Stream of pending invitations.
   Stream<List<Invitation>> get invitations => _service.invitationsStream();
 
+  /// Stream of all registered users.
+  Stream<List<User>> get users => _service.usersStream();
+
   /// Creates a new invitation for [email].
   Future<Invitation> invite(String email, {Set<UserRole> roles = const {}}) {
     return _service.inviteUser(email, roles: roles);
@@ -24,6 +27,26 @@ class AdminProvider extends ChangeNotifier {
   /// Removes [role] from [userId].
   Future<void> removeRole(String userId, UserRole role) {
     return _service.removeRole(userId, role);
+  }
+
+  /// Updates roles of [userId] to exactly match [roles].
+  Future<void> updateUserRoles(String userId, Set<UserRole> roles) {
+    return _service.updateUserRoles(userId, roles);
+  }
+
+  /// Accepts an invitation and creates the user with [name].
+  Future<void> acceptInvitation(String invitationId, String name) {
+    return _service.acceptInvitation(invitationId, name);
+  }
+
+  /// Declines the invitation with [invitationId].
+  Future<void> declineInvitation(String invitationId) {
+    return _service.declineInvitation(invitationId);
+  }
+
+  /// Deletes the user with [userId].
+  Future<void> deleteUser(String userId) {
+    return _service.deleteUser(userId);
   }
 }
 

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../core/admin_users_page.dart';
 import '../core/events_page.dart';
 import '../core/home_page.dart';
 import '../core/login_page.dart';
@@ -16,6 +17,7 @@ class AppRouter {
   static const events = '/events';
   static const tasks = '/tasks';
   static const settings = '/settings';
+  static const adminUsers = '/admin/users';
 
   static final GoRouter router = GoRouter(
     initialLocation: splash,
@@ -44,6 +46,11 @@ class AppRouter {
         path: settings,
         pageBuilder: (context, state) => _buildPage(state, const SettingsPage()),
       ),
+      GoRoute(
+        path: adminUsers,
+        pageBuilder: (context, state) =>
+            _buildPage(state, const AdminUsersPage()),
+      ),
     ],
   );
 
@@ -57,13 +64,5 @@ class AppRouter {
       },
     );
   }
-      GoRoute(path: splash, builder: (context, state) => const SplashPage()),
-      GoRoute(path: login, builder: (context, state) => const LoginPage()),
-      GoRoute(path: home, builder: (context, state) => const HomePage()),
-      GoRoute(path: events, builder: (context, state) => const EventsPage()),
-      GoRoute(path: tasks, builder: (context, state) => const TasksPage()),
-      GoRoute(path: settings, builder: (context, state) => const SettingsPage()),
-    ],
-  );
 }
 


### PR DESCRIPTION
## Summary
- add AdminService methods for listing users, handling invitations, updating roles, and deleting users
- expose new admin capabilities through AdminProvider and AdminUsersPage
- link user management screen via settings and router

## Testing
- `dart format lib/main.dart lib/providers/admin_provider.dart lib/services/admin_service.dart lib/core/admin_users_page.dart lib/core/settings_page.dart lib/routes/app_router.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890af335e84832387740f4a11634a97