### PR TITLE
Add role hierarchy, analytics chart, tests and CI

### DIFF
--- a/project/.github/workflows/ci.yml
+++ b/project/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Run tests
+        run: flutter test
+      - name: Build web
+        run: flutter build web --release
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/web

--- a/project/lib/core/admin_users_page.dart
+++ b/project/lib/core/admin_users_page.dart
@@ -5,6 +5,7 @@ import '../models/invitation.dart';
 import '../models/user.dart';
 import '../providers/admin_provider.dart';
 import '../services/analytics_service.dart';
+import 'widgets/user_stats_chart.dart';
 
 /// Administrative page that allows managing users and invitations.
 class AdminUsersPage extends StatefulWidget {
@@ -89,8 +90,12 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: Text(
-                        'Total: ${stats.totalUsers} • Admins: ${stats.adminCount} • Leaders: ${stats.leaderCount} • Assistants: ${stats.assistantCount}',
+                        'Total: ${stats.totalUsers} • Admins: ${stats.adminCount} • Senior Leaders: ${stats.seniorLeaderCount} • Leaders: ${stats.leaderCount} • Assistants: ${stats.assistantCount}',
                       ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: UserStatsChart(stats: stats),
                     ),
                     ListView.builder(
                       shrinkWrap: true,

--- a/project/lib/core/widgets/user_stats_chart.dart
+++ b/project/lib/core/widgets/user_stats_chart.dart
@@ -1,0 +1,47 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/admin_stats.dart';
+
+/// Displays a pie chart of user role distribution.
+class UserStatsChart extends StatelessWidget {
+  final AdminStats stats;
+  const UserStatsChart({super.key, required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = <PieChartSectionData>[
+      PieChartSectionData(
+        value: stats.adminCount.toDouble(),
+        color: Colors.red,
+        title: 'Admins',
+      ),
+      PieChartSectionData(
+        value: stats.seniorLeaderCount.toDouble(),
+        color: Colors.orange,
+        title: 'Senior',
+      ),
+      PieChartSectionData(
+        value: (stats.leaderCount - stats.seniorLeaderCount).toDouble(),
+        color: Colors.blue,
+        title: 'Leaders',
+      ),
+      PieChartSectionData(
+        value: stats.assistantCount.toDouble(),
+        color: Colors.green,
+        title: 'Assist',
+      ),
+    ].where((e) => e.value > 0).toList();
+
+    return SizedBox(
+      height: 200,
+      child: PieChart(
+        PieChartData(
+          sectionsSpace: 2,
+          centerSpaceRadius: 0,
+          sections: sections,
+        ),
+      ),
+    );
+  }
+}

--- a/project/lib/models/admin_stats.dart
+++ b/project/lib/models/admin_stats.dart
@@ -2,12 +2,14 @@ class AdminStats {
   final int totalUsers;
   final int adminCount;
   final int leaderCount;
+  final int seniorLeaderCount;
   final int assistantCount;
 
   const AdminStats({
     required this.totalUsers,
     required this.adminCount,
     required this.leaderCount,
+    required this.seniorLeaderCount,
     required this.assistantCount,
   });
 }

--- a/project/lib/models/user.dart
+++ b/project/lib/models/user.dart
@@ -1,5 +1,8 @@
 /// Roles that a [User] can have inside the application.
-enum UserRole { admin, leader, assistant }
+///
+/// The [seniorLeader] role acts as a sub-role of [leader] with extended
+/// permissions.
+enum UserRole { admin, leader, seniorLeader, assistant }
 
 /// Represents a leader or staff member who can use the application.
 class User {
@@ -18,8 +21,9 @@ class User {
     this.roles = const {},
   });
 
-  /// Convenience getter to check if the user is a leader.
-  bool get isLeader => roles.contains(UserRole.leader);
+  /// Convenience getter to check if the user is a leader of any level.
+  bool get isLeader =>
+      roles.contains(UserRole.leader) || roles.contains(UserRole.seniorLeader);
 
   /// Creates a [User] instance from JSON.
   factory User.fromJson(Map<String, dynamic> json) {

--- a/project/lib/services/admin_service.dart
+++ b/project/lib/services/admin_service.dart
@@ -7,8 +7,12 @@ import '../models/user.dart';
 
 /// Provides administrative user management features.
 class AdminService {
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  final Random _random = Random();
+  final FirebaseFirestore _firestore;
+  final Random _random;
+
+  AdminService({FirebaseFirestore? firestore, Random? random})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _random = random ?? Random();
 
   /// Generates a simple random token for invitations.
   String _generateToken() => _random.nextInt(1 << 32).toRadixString(16);

--- a/project/lib/services/analytics_service.dart
+++ b/project/lib/services/analytics_service.dart
@@ -7,16 +7,23 @@ class AnalyticsService {
   AdminStats buildUserStats(List<User> users) {
     int admins = 0;
     int leaders = 0;
+    int seniorLeaders = 0;
     int assistants = 0;
     for (final u in users) {
       if (u.roles.contains(UserRole.admin)) admins++;
-      if (u.roles.contains(UserRole.leader)) leaders++;
+      if (u.roles.contains(UserRole.seniorLeader)) {
+        seniorLeaders++;
+        leaders++; // senior leaders are also leaders
+      } else if (u.roles.contains(UserRole.leader)) {
+        leaders++;
+      }
       if (u.roles.contains(UserRole.assistant)) assistants++;
     }
     return AdminStats(
       totalUsers: users.length,
       adminCount: admins,
       leaderCount: leaders,
+      seniorLeaderCount: seniorLeaders,
       assistantCount: assistants,
     );
   }

--- a/project/pubspec.yaml
+++ b/project/pubspec.yaml
@@ -16,8 +16,10 @@ dependencies:
   connectivity_plus: ^4.0.0
   pdf: ^3.10.4
   firebase_storage: ^11.0.16
+  fl_chart: ^0.60.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  fake_cloud_firestore: ^2.3.0
 flutter:
   uses-material-design: true

--- a/project/test/admin_service_test.dart
+++ b/project/test/admin_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:camp_leader/models/user.dart';
+import 'package:camp_leader/services/admin_service.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AdminService', () {
+    test('invites and accepts users', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = AdminService(firestore: firestore);
+
+      final invite = await service.inviteUser('test@example.com', roles: {UserRole.leader});
+      expect(invite.email, 'test@example.com');
+
+      await service.acceptInvitation(invite.id, 'Tester');
+      final usersSnap = await firestore.collection('users').get();
+      expect(usersSnap.docs.length, 1);
+      final data = usersSnap.docs.first.data();
+      expect(data['name'], 'Tester');
+      expect((data['roles'] as List).contains('leader'), isTrue);
+      final invites = await firestore.collection('invitations').get();
+      expect(invites.docs.isEmpty, isTrue);
+    });
+
+    test('assigns and removes roles', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = AdminService(firestore: firestore);
+      final userRef = firestore.collection('users').doc('u1');
+      await userRef.set({'name': 'Tester', 'roles': []});
+
+      await service.assignRole('u1', UserRole.admin);
+      var snap = await userRef.get();
+      expect(List<String>.from(snap.data()!['roles']).contains('admin'), isTrue);
+
+      await service.removeRole('u1', UserRole.admin);
+      snap = await userRef.get();
+      expect(List<String>.from(snap.data()!['roles']).contains('admin'), isFalse);
+    });
+  });
+}

--- a/project/test/analytics_service_test.dart
+++ b/project/test/analytics_service_test.dart
@@ -1,0 +1,24 @@
+import 'package:camp_leader/models/user.dart';
+import 'package:camp_leader/services/analytics_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AnalyticsService', () {
+    test('buildUserStats counts roles including senior leaders', () {
+      final service = AnalyticsService();
+      final users = [
+        User(id: '1', name: 'A', roles: {UserRole.admin}),
+        User(id: '2', name: 'B', roles: {UserRole.leader}),
+        User(id: '3', name: 'C', roles: {UserRole.seniorLeader}),
+        User(id: '4', name: 'D', roles: {UserRole.assistant}),
+        User(id: '5', name: 'E', roles: {UserRole.admin, UserRole.seniorLeader}),
+      ];
+      final stats = service.buildUserStats(users);
+      expect(stats.totalUsers, 5);
+      expect(stats.adminCount, 2);
+      expect(stats.leaderCount, 3);
+      expect(stats.seniorLeaderCount, 2);
+      expect(stats.assistantCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `seniorLeader` role and update analytics/statistics
- visualize user role distribution with a pie chart in admin panel
- introduce unit/integration tests and GitHub Actions CI workflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890d13a9a78832399d7fbea4d3edeb3