### PR TITLE
Fix task/event scheduling and add bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,19 @@
 # Camp Leader
 
-Camp Leader is a Flutter prototype that helps camp leaders plan events, track tasks, and stay in touch with their teams.
+## English
 
-## Table of Contents
-- [Features](#features)
-- [For All Users](#for-all-users)
-- [Project Structure](#project-structure)
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Running](#running)
-- [Running Tests](#running-tests)
-- [Contributing](#contributing)
-- [License](#license)
+Camp Leader is a Flutter prototype that helps camp leaders plan events, manage tasks and stay in touch with their teams.
 
-## Features
-- **Authentication**: simulated login/logout flow using a basic `AuthService`.
-- **Events**: create events with categories, priorities, repeat intervals, and local notifications.
-- **Tasks**: track tasks with priority, repeat schedules, reminders, and the ability to reorder and toggle completion.
-- **Chat**: Firestore‑backed chat with attachments, read receipts, and typing indicators.
-- **Admin tools**: manage users and invitations, edit roles, and generate PDF reports.
-- **Offline support**: persist tasks and events locally and sync them automatically when connectivity returns.
-- **Theming & routing**: light and dark themes and navigation powered by `go_router`.
+### Features
+- **Authentication** – basic login/logout flow using a mocked `AuthService`.
+- **Events** – create events with categories, priorities, repeat intervals and local notifications.
+- **Tasks** – track tasks with priority, repeat schedules, reminders and the ability to reorder and toggle completion.
+- **Chat** – Firestore‑backed chat with attachments, read receipts and typing indicators.
+- **Admin tools** – manage users and invitations, edit roles and generate PDF reports.
+- **Offline support** – persist tasks and events locally and sync them automatically when connectivity returns.
+- **Theming & routing** – light and dark themes and navigation powered by `go_router`.
 
-## For All Users
-Camp Leader welcomes campers and administrators alike. If you're trying out the app or planning to contribute, start with [Getting Started](#getting-started) for setup instructions and visit [Contributing](#contributing) to learn how to share feedback and improvements.
-
-## Project Structure
+### Project Structure
 ```
 project/
   lib/
@@ -39,30 +26,99 @@ project/
   pubspec.yaml
 ```
 
-## Getting Started
-
-### Prerequisites
-- [Flutter SDK](https://flutter.dev) (compatible with Dart >=2.17 <3.0)
-- A configured Firebase project for Firestore and Storage
+### Getting Started
+#### Prerequisites
+- [Flutter SDK](https://flutter.dev) (Dart >=3.0.0 <4.0.0)
+- Configured Firebase project for Firestore and Storage
 - Optional: Sentry account for error reporting
 
-### Installation
+#### Installation
 ```bash
 flutter pub get
 ```
 
-### Running
-```bash
-flutter run
-```
+#### Running
+Choose a target and run the application:
 
-## Running Tests
+| Platform | Command |
+| --- | --- |
+| Android | `flutter run -d android` |
+| iOS | `flutter run -d ios` |
+| Web | `flutter run -d chrome` |
+| Linux | `flutter run -d linux` |
+| macOS | `flutter run -d macos` |
+| Windows | `flutter run -d windows` |
+
+#### Running Tests
 ```bash
 flutter test
 ```
 
-## Contributing
-Contributions, issues, and feature requests are welcome. Feel free to open a pull request to propose changes.
+### Contributing
+Contributions, issues and feature requests are welcome. Open a pull request to propose changes.
 
-## License
+### License
 This project is provided as‑is without a specified license.
+
+---
+
+## Русский
+
+Camp Leader — это прототип Flutter, помогающий руководителям лагерей планировать события, управлять задачами и поддерживать связь с командой.
+
+### Возможности
+- **Аутентификация** — базовый вход и выход с использованием фиктивного `AuthService`.
+- **События** — создание событий с категориями, приоритетами, интервалами повторения и локальными уведомлениями.
+- **Задачи** — отслеживание задач с приоритетом, расписанием повторений, напоминаниями, а также возможность менять порядок и отмечать выполнение.
+- **Чат** — чат на Firestore с вложениями, уведомлениями о прочтении и индикаторами набора текста.
+- **Админ‑инструменты** — управление пользователями и приглашениями, редактирование ролей и генерация PDF‑отчётов.
+- **Оффлайн‑поддержка** — локальное сохранение задач и событий с автоматической синхронизацией при появлении сети.
+- **Темы и маршруты** — светлая и тёмная темы, навигация на базе `go_router`.
+
+### Структура проекта
+```
+project/
+  lib/
+    core/        # Интерфейсные страницы
+    models/      # Модели данных (Event, Task, User)
+    providers/   # Управление состоянием через Provider
+    routes/      # Конфигурация GoRouter
+    services/    # Auth, чат, уведомления, оффлайн‑синхронизация, отчёты
+    theme.dart   # Определение тем
+  pubspec.yaml
+```
+
+### Начало работы
+#### Предварительные требования
+- [Flutter SDK](https://flutter.dev) (Dart >=3.0.0 <4.0.0)
+- Настроенный проект Firebase для Firestore и Storage
+- Необязательно: учётная запись Sentry для отчётов об ошибках
+
+#### Установка зависимостей
+```bash
+flutter pub get
+```
+
+#### Запуск
+Выберите целевую платформу и выполните:
+
+| Платформа | Команда |
+| --- | --- |
+| Android | `flutter run -d android` |
+| iOS | `flutter run -d ios` |
+| Web | `flutter run -d chrome` |
+| Linux | `flutter run -d linux` |
+| macOS | `flutter run -d macos` |
+| Windows | `flutter run -d windows` |
+
+#### Запуск тестов
+```bash
+flutter test
+```
+
+### Участие
+Мы приветствуем вклад, проблемы и запросы на новые функции. Отправляйте pull‑request с предложениями изменений.
+
+### Лицензия
+Проект предоставляется «как есть» без указанной лицензии.
+

--- a/project/README.md
+++ b/project/README.md
@@ -1,16 +1,8 @@
-# camp_leader
+# Camp Leader
 
-A new Flutter project.
+For complete documentation, including English and Russian instructions and platform‑specific launch steps, see the [repository root README](../README.md).
 
-## Getting Started
+# Camp Leader
 
-This project is a starting point for a Flutter application.
+Полную документацию на английском и русском языках, а также инструкции по запуску на разных платформах смотрите в [корневом README](../README.md).
 
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.

--- a/project/lib/core/events_page.dart
+++ b/project/lib/core/events_page.dart
@@ -102,12 +102,6 @@ class EventsPage extends StatelessWidget {
                     interval,
                   );
                 }
-                await NotificationService().scheduleReminder(
-                  id.hashCode,
-                  'Event Reminder',
-                  titleController.text.trim(),
-                  DateTime.now().add(const Duration(seconds: 5)),
-                );
 
                 Navigator.pop(context);
               }

--- a/project/lib/core/tasks_page.dart
+++ b/project/lib/core/tasks_page.dart
@@ -93,15 +93,6 @@ class TasksPage extends StatelessWidget {
                     interval,
                   );
                 }
-                context
-                    .read<TaskProvider>()
-                    .addTask(Task(id: id, description: descController.text.trim()));
-                await NotificationService().scheduleReminder(
-                  id.hashCode,
-                  'Task Reminder',
-                  descController.text.trim(),
-                  DateTime.now().add(const Duration(seconds: 5)),
-                );
                 Navigator.pop(context);
               }
             },


### PR DESCRIPTION
## Summary
- fix duplicated task addition and reminder scheduling
- remove extra event reminder
- add bilingual README with platform-specific launch instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a22f31e883239e1970197e7b4f7d